### PR TITLE
deploy service dependecies using ecr images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20874,7 +20874,7 @@
       "dependencies": {
         "@cdktf/provider-aws": "12.0.5",
         "@cdktf/provider-random": "^5.0.0",
-        "arc-cdk": "^0.0.3",
+        "arc-cdk": "^0.0.8",
         "cdktf": "^0.15.5",
         "constructs": "^10.1.257"
       },
@@ -20918,6 +20918,32 @@
       "peerDependencies": {
         "cdktf": "^0.15.0",
         "constructs": "^10.0.0"
+      }
+    },
+    "packages/arc-feature-toggle/node_modules/arc-cdk": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/arc-cdk/-/arc-cdk-0.0.8.tgz",
+      "integrity": "sha512-hJy9FgArgFeKUwdVOlVsfE77b/zvg6g2oDvXEFBALiemWq1sXHVVZlKxoiKSrk2crath0D3FNDr8nGJ8err6mg==",
+      "bundleDependencies": [
+        "short-unique-id"
+      ],
+      "dependencies": {
+        "short-unique-id": "^4.4.4"
+      },
+      "peerDependencies": {
+        "@cdktf/provider-aws": "^12.0.4",
+        "@cdktf/provider-docker": "^6.0.1",
+        "cdktf": "^0.15.3",
+        "constructs": "^10.1.232"
+      }
+    },
+    "packages/arc-feature-toggle/node_modules/arc-cdk/node_modules/short-unique-id": {
+      "version": "4.4.4",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "short-unique-id": "bin/short-unique-id",
+        "suid": "bin/short-unique-id"
       }
     },
     "packages/arc-feature-toggle/node_modules/typescript": {
@@ -20976,7 +21002,7 @@
       "dependencies": {
         "@cdktf/provider-aws": "^12.0.1",
         "@cdktf/provider-random": "^5.0.0",
-        "arc-cdk": "^0.0.3",
+        "arc-cdk": "^0.0.8",
         "cdktf": "^0.15.0",
         "constructs": "^10.1.229",
         "dotenv": "^16.0.3",
@@ -21012,6 +21038,32 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "packages/arc-in-mail/node_modules/arc-cdk": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/arc-cdk/-/arc-cdk-0.0.8.tgz",
+      "integrity": "sha512-hJy9FgArgFeKUwdVOlVsfE77b/zvg6g2oDvXEFBALiemWq1sXHVVZlKxoiKSrk2crath0D3FNDr8nGJ8err6mg==",
+      "bundleDependencies": [
+        "short-unique-id"
+      ],
+      "dependencies": {
+        "short-unique-id": "^4.4.4"
+      },
+      "peerDependencies": {
+        "@cdktf/provider-aws": "^12.0.4",
+        "@cdktf/provider-docker": "^6.0.1",
+        "cdktf": "^0.15.3",
+        "constructs": "^10.1.232"
+      }
+    },
+    "packages/arc-in-mail/node_modules/arc-cdk/node_modules/short-unique-id": {
+      "version": "4.4.4",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "short-unique-id": "bin/short-unique-id",
+        "suid": "bin/short-unique-id"
       }
     },
     "packages/arc-in-mail/node_modules/loopback-connector": {
@@ -21108,7 +21160,7 @@
       "dependencies": {
         "@cdktf/provider-aws": "^12.0.1",
         "@cdktf/provider-random": "^5.0.0",
-        "arc-cdk": "^0.0.3",
+        "arc-cdk": "^0.0.8",
         "cdktf": "^0.15.0",
         "constructs": "^10.1.229",
         "dotenv": "^16.0.3",
@@ -21144,6 +21196,32 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "packages/arc-payment/node_modules/arc-cdk": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/arc-cdk/-/arc-cdk-0.0.8.tgz",
+      "integrity": "sha512-hJy9FgArgFeKUwdVOlVsfE77b/zvg6g2oDvXEFBALiemWq1sXHVVZlKxoiKSrk2crath0D3FNDr8nGJ8err6mg==",
+      "bundleDependencies": [
+        "short-unique-id"
+      ],
+      "dependencies": {
+        "short-unique-id": "^4.4.4"
+      },
+      "peerDependencies": {
+        "@cdktf/provider-aws": "^12.0.4",
+        "@cdktf/provider-docker": "^6.0.1",
+        "cdktf": "^0.15.3",
+        "constructs": "^10.1.232"
+      }
+    },
+    "packages/arc-payment/node_modules/arc-cdk/node_modules/short-unique-id": {
+      "version": "4.4.4",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "short-unique-id": "bin/short-unique-id",
+        "suid": "bin/short-unique-id"
       }
     },
     "packages/arc-payment/node_modules/typescript": {
@@ -21203,7 +21281,7 @@
       "dependencies": {
         "@cdktf/provider-aws": "^12.0.5",
         "@cdktf/provider-random": "^5.0.0",
-        "arc-cdk": "^0.0.3",
+        "arc-cdk": "^0.0.8",
         "cdktf": "^0.15.0",
         "constructs": "^10.1.229",
         "dotenv": "^16.0.3",
@@ -21239,6 +21317,32 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "packages/arc-scheduler/node_modules/arc-cdk": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/arc-cdk/-/arc-cdk-0.0.8.tgz",
+      "integrity": "sha512-hJy9FgArgFeKUwdVOlVsfE77b/zvg6g2oDvXEFBALiemWq1sXHVVZlKxoiKSrk2crath0D3FNDr8nGJ8err6mg==",
+      "bundleDependencies": [
+        "short-unique-id"
+      ],
+      "dependencies": {
+        "short-unique-id": "^4.4.4"
+      },
+      "peerDependencies": {
+        "@cdktf/provider-aws": "^12.0.4",
+        "@cdktf/provider-docker": "^6.0.1",
+        "cdktf": "^0.15.3",
+        "constructs": "^10.1.232"
+      }
+    },
+    "packages/arc-scheduler/node_modules/arc-cdk/node_modules/short-unique-id": {
+      "version": "4.4.4",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "short-unique-id": "bin/short-unique-id",
+        "suid": "bin/short-unique-id"
       }
     },
     "packages/arc-scheduler/node_modules/loopback-connector": {
@@ -21334,7 +21438,7 @@
       "dependencies": {
         "@cdktf/provider-aws": "^12.0.1",
         "@cdktf/provider-random": "^5.0.0",
-        "arc-cdk": "^0.0.3",
+        "arc-cdk": "^0.0.8",
         "cdktf": "^0.15.0",
         "constructs": "^10.1.229",
         "dotenv": "^16.0.3",
@@ -21370,6 +21474,32 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "packages/arc-search/node_modules/arc-cdk": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/arc-cdk/-/arc-cdk-0.0.8.tgz",
+      "integrity": "sha512-hJy9FgArgFeKUwdVOlVsfE77b/zvg6g2oDvXEFBALiemWq1sXHVVZlKxoiKSrk2crath0D3FNDr8nGJ8err6mg==",
+      "bundleDependencies": [
+        "short-unique-id"
+      ],
+      "dependencies": {
+        "short-unique-id": "^4.4.4"
+      },
+      "peerDependencies": {
+        "@cdktf/provider-aws": "^12.0.4",
+        "@cdktf/provider-docker": "^6.0.1",
+        "cdktf": "^0.15.3",
+        "constructs": "^10.1.232"
+      }
+    },
+    "packages/arc-search/node_modules/arc-cdk/node_modules/short-unique-id": {
+      "version": "4.4.4",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "short-unique-id": "bin/short-unique-id",
+        "suid": "bin/short-unique-id"
       }
     },
     "packages/arc-search/node_modules/loopback-connector": {
@@ -21477,7 +21607,7 @@
       "dependencies": {
         "@cdktf/provider-aws": "^12.0.1",
         "@cdktf/provider-random": "^5.0.0",
-        "arc-cdk": "^0.0.3",
+        "arc-cdk": "^0.0.8",
         "cdktf": "^0.15.0",
         "constructs": "^10.1.229",
         "dotenv": "^16.0.3",
@@ -21513,6 +21643,32 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "packages/arc-user-tenant/node_modules/arc-cdk": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/arc-cdk/-/arc-cdk-0.0.8.tgz",
+      "integrity": "sha512-hJy9FgArgFeKUwdVOlVsfE77b/zvg6g2oDvXEFBALiemWq1sXHVVZlKxoiKSrk2crath0D3FNDr8nGJ8err6mg==",
+      "bundleDependencies": [
+        "short-unique-id"
+      ],
+      "dependencies": {
+        "short-unique-id": "^4.4.4"
+      },
+      "peerDependencies": {
+        "@cdktf/provider-aws": "^12.0.4",
+        "@cdktf/provider-docker": "^6.0.1",
+        "cdktf": "^0.15.3",
+        "constructs": "^10.1.232"
+      }
+    },
+    "packages/arc-user-tenant/node_modules/arc-cdk/node_modules/short-unique-id": {
+      "version": "4.4.4",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "short-unique-id": "bin/short-unique-id",
+        "suid": "bin/short-unique-id"
       }
     },
     "packages/arc-user-tenant/node_modules/jsonwebtoken": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -602,6 +602,19 @@
         "constructs": "^10.0.0"
       }
     },
+    "node_modules/@cdktf/provider-docker": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@cdktf/provider-docker/-/provider-docker-6.0.1.tgz",
+      "integrity": "sha512-nNek5dbGcEtHq0Kw0jXP26TvkXjMXa1zY1DkzYuVBsvU/PKQCpE2q5ubwZ5cZeJ9NAXqfvaeHnZdyBlWcwmbcQ==",
+      "peer": true,
+      "engines": {
+        "node": ">= 14.17.0"
+      },
+      "peerDependencies": {
+        "cdktf": "^0.15.0",
+        "constructs": "^10.0.0"
+      }
+    },
     "node_modules/@cdktf/provider-random": {
       "version": "5.0.0",
       "license": "MPL-2.0",
@@ -20234,7 +20247,7 @@
       "dependencies": {
         "@cdktf/provider-aws": "^12.0.5",
         "@cdktf/provider-random": "^5.0.0",
-        "arc-cdk": "^0.0.3",
+        "arc-cdk": "^0.0.8",
         "cdktf": "^0.15.0",
         "constructs": "^10.1.229",
         "dotenv": "^16.0.3",
@@ -20270,6 +20283,32 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "packages/arc-audit/node_modules/arc-cdk": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/arc-cdk/-/arc-cdk-0.0.8.tgz",
+      "integrity": "sha512-hJy9FgArgFeKUwdVOlVsfE77b/zvg6g2oDvXEFBALiemWq1sXHVVZlKxoiKSrk2crath0D3FNDr8nGJ8err6mg==",
+      "bundleDependencies": [
+        "short-unique-id"
+      ],
+      "dependencies": {
+        "short-unique-id": "^4.4.4"
+      },
+      "peerDependencies": {
+        "@cdktf/provider-aws": "^12.0.4",
+        "@cdktf/provider-docker": "^6.0.1",
+        "cdktf": "^0.15.3",
+        "constructs": "^10.1.232"
+      }
+    },
+    "packages/arc-audit/node_modules/arc-cdk/node_modules/short-unique-id": {
+      "version": "4.4.4",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "short-unique-id": "bin/short-unique-id",
+        "suid": "bin/short-unique-id"
       }
     },
     "packages/arc-audit/node_modules/typescript": {
@@ -20422,7 +20461,7 @@
       "dependencies": {
         "@cdktf/provider-aws": "^12.0.1",
         "@cdktf/provider-random": "^5.0.0",
-        "arc-cdk": "^0.0.3",
+        "arc-cdk": "^0.0.8",
         "cdktf": "^0.15.0",
         "constructs": "^10.1.229",
         "dotenv": "^16.0.3",
@@ -20507,6 +20546,32 @@
       "peerDependencies": {
         "db-migrate": "^1.0.0-beta.18",
         "db-migrate-pg": "^1.2.2"
+      }
+    },
+    "packages/arc-auth/node_modules/arc-cdk": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/arc-cdk/-/arc-cdk-0.0.8.tgz",
+      "integrity": "sha512-hJy9FgArgFeKUwdVOlVsfE77b/zvg6g2oDvXEFBALiemWq1sXHVVZlKxoiKSrk2crath0D3FNDr8nGJ8err6mg==",
+      "bundleDependencies": [
+        "short-unique-id"
+      ],
+      "dependencies": {
+        "short-unique-id": "^4.4.4"
+      },
+      "peerDependencies": {
+        "@cdktf/provider-aws": "^12.0.4",
+        "@cdktf/provider-docker": "^6.0.1",
+        "cdktf": "^0.15.3",
+        "constructs": "^10.1.232"
+      }
+    },
+    "packages/arc-auth/node_modules/arc-cdk/node_modules/short-unique-id": {
+      "version": "4.4.4",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "short-unique-id": "bin/short-unique-id",
+        "suid": "bin/short-unique-id"
       }
     },
     "packages/arc-auth/node_modules/loopback-connector": {
@@ -20652,7 +20717,8 @@
       "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@cdktf/provider-aws": "12.0.8"
+        "@cdktf/provider-aws": "12.0.8",
+        "arc-cdk": "^0.0.8"
       },
       "devDependencies": {
         "@types/jest": "^29.4.0",
@@ -20683,6 +20749,32 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "packages/arc-bpmn/node_modules/arc-cdk": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/arc-cdk/-/arc-cdk-0.0.8.tgz",
+      "integrity": "sha512-hJy9FgArgFeKUwdVOlVsfE77b/zvg6g2oDvXEFBALiemWq1sXHVVZlKxoiKSrk2crath0D3FNDr8nGJ8err6mg==",
+      "bundleDependencies": [
+        "short-unique-id"
+      ],
+      "dependencies": {
+        "short-unique-id": "^4.4.4"
+      },
+      "peerDependencies": {
+        "@cdktf/provider-aws": "^12.0.4",
+        "@cdktf/provider-docker": "^6.0.1",
+        "cdktf": "^0.15.3",
+        "constructs": "^10.1.232"
+      }
+    },
+    "packages/arc-bpmn/node_modules/arc-cdk/node_modules/short-unique-id": {
+      "version": "4.4.4",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "short-unique-id": "bin/short-unique-id",
+        "suid": "bin/short-unique-id"
       }
     },
     "packages/arc-bpmn/node_modules/loopback-connector": {

--- a/packages/arc-audit/Dockerfile
+++ b/packages/arc-audit/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR ${LAMBDA_TASK_ROOT}
 # Install app dependencies
 COPY package*.json ./
 
-RUN npm install --ignore-scripts
+RUN npm install
 
 # Bundle app source code
 COPY . .
@@ -17,4 +17,4 @@ COPY . .
 # Build Loopback app
 RUN npm run build
 
-CMD [ "./dist/main.handler" ]
+CMD [ "./dist/lambda.handler" ]

--- a/packages/arc-audit/Dockerfile
+++ b/packages/arc-audit/Dockerfile
@@ -1,5 +1,5 @@
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:16 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}

--- a/packages/arc-audit/cdk/common/stacks/lambda.stack.ts
+++ b/packages/arc-audit/cdk/common/stacks/lambda.stack.ts
@@ -1,8 +1,9 @@
 import * as random from "@cdktf/provider-random";
+import {ILambdaWithApiGateway, LambdaWithApiGateway} from "arc-cdk";
 import {TerraformStack} from "cdktf";
 import {Construct} from "constructs";
-import {ILambdaWithApiGateway, LambdaWithApiGateway} from "arc-cdk";
 import {AwsProvider} from "../constructs/awsProvider";
+import path = require('path');
 
 export class LambdaStack extends TerraformStack {
   constructor(
@@ -20,7 +21,10 @@ export class LambdaStack extends TerraformStack {
       length: 2,
     });
 
-    new LambdaWithApiGateway(this, "lambda-apiGateway", {// NOSONAR
+    // overwrite codePath based on useImage as deploy via docker needs different codePath
+    config.codePath = path.resolve(config.codePath, `../${config.useImage ? '' : 'dist'}`);
+
+    new LambdaWithApiGateway(this, 'lambda-apiGateway', {
       ...config,
       name: pet.id,
     });

--- a/packages/arc-audit/cdk/common/stacks/lambda.stack.ts
+++ b/packages/arc-audit/cdk/common/stacks/lambda.stack.ts
@@ -24,7 +24,7 @@ export class LambdaStack extends TerraformStack {
     // overwrite codePath based on useImage as deploy via docker needs different codePath
     config.codePath = path.resolve(config.codePath, `../${config.useImage ? '' : 'dist'}`);
 
-    new LambdaWithApiGateway(this, 'lambda-apiGateway', {
+    new LambdaWithApiGateway(this, 'lambda-apiGateway', {// NOSONAR
       ...config,
       name: pet.id,
     });

--- a/packages/arc-audit/cdk/main.ts
+++ b/packages/arc-audit/cdk/main.ts
@@ -57,7 +57,7 @@ new MigrationStack(app, "migration", {// NOSONAR
 
 new LambdaStack(app, "lambda", {// NOSONAR
   s3Bucket: process.env.S3_BUCKET!,
-  codePath: resolve(__dirname, "../dist"),
+  codePath: __dirname,
   handler: "lambda.handler",
   runtime: "nodejs16.x",
   layerPath: resolve(__dirname, "../layers"),
@@ -86,6 +86,7 @@ new LambdaStack(app, "lambda", {// NOSONAR
   },
   namespace: process.env.NAMESPACE || "",
   environment: process.env.ENV || "",
+  useImage: true,
 });
 
 app.synth();

--- a/packages/arc-audit/cdk/main.ts
+++ b/packages/arc-audit/cdk/main.ts
@@ -36,7 +36,7 @@ const getSecurityGroup = () => {
 new MigrationStack(app, "migration", {// NOSONAR
   codePath: resolve(__dirname, "../migration"),
   handler: "lambda.handler",
-  runtime: "nodejs16.x",
+  runtime: "nodejs18.x",
   vpcConfig: {
     securityGroupIds: getSecurityGroup(),
     subnetIds: getSubnetIds(),
@@ -59,7 +59,7 @@ new LambdaStack(app, "lambda", {// NOSONAR
   s3Bucket: process.env.S3_BUCKET!,
   codePath: __dirname,
   handler: "lambda.handler",
-  runtime: "nodejs16.x",
+  runtime: "nodejs18.x",
   layerPath: resolve(__dirname, "../layers"),
   vpcConfig: {
     securityGroupIds: getSecurityGroup(),

--- a/packages/arc-audit/cdk/package.json
+++ b/packages/arc-audit/cdk/package.json
@@ -29,7 +29,7 @@
     "constructs": "^10.1.229",
     "dotenv": "^16.0.3",
     "dotenv-extended": "^2.9.0",
-    "arc-cdk": "^0.0.3"
+    "arc-cdk": "^0.0.8"
   },
   "devDependencies": {
     "@types/jest": "^29.2.6",

--- a/packages/arc-auth/Dockerfile
+++ b/packages/arc-auth/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR ${LAMBDA_TASK_ROOT}
 # Install app dependencies
 COPY package*.json ./
 
-RUN npm install --ignore-scripts
+RUN npm install
 
 # Bundle app source code
 COPY . .
@@ -17,4 +17,4 @@ COPY . .
 # Build Loopback app
 RUN npm run build
 
-CMD [ "./dist/main.handler" ]
+CMD [ "./dist/lambda.handler" ]

--- a/packages/arc-auth/Dockerfile
+++ b/packages/arc-auth/Dockerfile
@@ -1,5 +1,5 @@
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:16 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}

--- a/packages/arc-auth/cdk/__tests__/__snapshots__/lambda.stack.test.ts.snap
+++ b/packages/arc-auth/cdk/__tests__/__snapshots__/lambda.stack.test.ts.snap
@@ -76,7 +76,7 @@ exports[`My CDKTF Application with all config set should match snapshot test 1`]
         ],
         "memory_size": 256,
         "role": "\${aws_iam_role.lambda-exec.arn}",
-        "runtime": "nodejs16.x",
+        "runtime": "nodejs18.x",
         "vpc_config": {
           "security_group_ids": [
             "sg-123456"

--- a/packages/arc-auth/cdk/__tests__/lambda.stack.test.ts
+++ b/packages/arc-auth/cdk/__tests__/lambda.stack.test.ts
@@ -32,7 +32,7 @@ expect.addSnapshotSerializer({
 });
 
 const handler = 'lambda.handler';
-const runtime = 'nodejs16.x';
+const runtime = 'nodejs18.x';
 const version = 'v0.0.1';
 const subnetIds = ['subnet-123456'];
 const securityGroupIds = ['sg-123456'];

--- a/packages/arc-auth/cdk/common/stacks/lambda.stack.ts
+++ b/packages/arc-auth/cdk/common/stacks/lambda.stack.ts
@@ -1,8 +1,9 @@
 import * as random from '@cdktf/provider-random';
+import {ILambdaWithApiGateway, LambdaWithApiGateway} from 'arc-cdk';
 import {TerraformStack} from 'cdktf';
 import {Construct} from 'constructs';
-import {ILambdaWithApiGateway, LambdaWithApiGateway} from 'arc-cdk';
 import {AwsProvider} from '../constructs/awsProvider';
+import path = require('path');
 
 export class LambdaStack extends TerraformStack {
   constructor(
@@ -20,7 +21,10 @@ export class LambdaStack extends TerraformStack {
       length: 2,
     });
 
-    new LambdaWithApiGateway(this, 'lambda-apiGateway', {// NOSONAR
+    // overwrite codePath based on useImage as deploy via docker needs different codePath
+    config.codePath = path.resolve(config.codePath, `../${config.useImage ? '' : 'dist'}`);
+
+    new LambdaWithApiGateway(this, 'lambda-apiGateway', {
       ...config,
       name: pet.id,
     });

--- a/packages/arc-auth/cdk/common/stacks/lambda.stack.ts
+++ b/packages/arc-auth/cdk/common/stacks/lambda.stack.ts
@@ -24,7 +24,7 @@ export class LambdaStack extends TerraformStack {
     // overwrite codePath based on useImage as deploy via docker needs different codePath
     config.codePath = path.resolve(config.codePath, `../${config.useImage ? '' : 'dist'}`);
 
-    new LambdaWithApiGateway(this, 'lambda-apiGateway', {
+    new LambdaWithApiGateway(this, 'lambda-apiGateway', {// NOSONAR
       ...config,
       name: pet.id,
     });

--- a/packages/arc-auth/cdk/main.ts
+++ b/packages/arc-auth/cdk/main.ts
@@ -36,7 +36,7 @@ const getSecurityGroup = () => {
 new MigrationStack(app, 'migration', { // NOSONAR
   codePath: resolve(__dirname, '../migration'),
   handler: 'lambda.handler',
-  runtime: 'nodejs16.x',
+  runtime: 'nodejs18.x',
   vpcConfig: {
     securityGroupIds: getSecurityGroup(),
     subnetIds: getSubnetIds(),
@@ -59,7 +59,7 @@ new LambdaStack(app, 'lambda', {// NOSONAR
   s3Bucket: process.env.S3_BUCKET!,
   codePath: __dirname,
   handler: 'lambda.handler',
-  runtime: 'nodejs16.x',
+  runtime: 'nodejs18.x',
   layerPath: resolve(__dirname, '../layers'),
   vpcConfig: {
     securityGroupIds: getSecurityGroup(),

--- a/packages/arc-auth/cdk/main.ts
+++ b/packages/arc-auth/cdk/main.ts
@@ -57,7 +57,7 @@ new MigrationStack(app, 'migration', { // NOSONAR
 
 new LambdaStack(app, 'lambda', {// NOSONAR
   s3Bucket: process.env.S3_BUCKET!,
-  codePath: resolve(__dirname, '../dist'),
+  codePath: __dirname,
   handler: 'lambda.handler',
   runtime: 'nodejs16.x',
   layerPath: resolve(__dirname, '../layers'),
@@ -86,6 +86,7 @@ new LambdaStack(app, 'lambda', {// NOSONAR
   },
   namespace: process.env.NAMESPACE || '',
   environment: process.env.ENV || '',
+  useImage: true,
 });
 
 new RedisStack(app, 'redis', {// NOSONAR

--- a/packages/arc-auth/cdk/package.json
+++ b/packages/arc-auth/cdk/package.json
@@ -25,11 +25,11 @@
   "dependencies": {
     "@cdktf/provider-aws": "^12.0.1",
     "@cdktf/provider-random": "^5.0.0",
+    "arc-cdk": "^0.0.8",
     "cdktf": "^0.15.0",
     "constructs": "^10.1.229",
     "dotenv": "^16.0.3",
-    "dotenv-extended": "^2.9.0",
-    "arc-cdk": "^0.0.3"
+    "dotenv-extended": "^2.9.0"
   },
   "devDependencies": {
     "@types/jest": "^29.2.6",

--- a/packages/arc-bpmn/Dockerfile
+++ b/packages/arc-bpmn/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR ${LAMBDA_TASK_ROOT}
 # Install app dependencies
 COPY package*.json ./
 
-RUN npm install --ignore-scripts
+RUN npm install
 
 # Bundle app source code
 COPY . .
@@ -17,4 +17,4 @@ COPY . .
 # Build Loopback app
 RUN npm run build
 
-CMD [ "./dist/main.handler" ]
+CMD [ "./dist/lambda.handler" ]

--- a/packages/arc-bpmn/Dockerfile
+++ b/packages/arc-bpmn/Dockerfile
@@ -1,5 +1,5 @@
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:16 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}

--- a/packages/arc-bpmn/cdk/common/stacks/lambda.stack.ts
+++ b/packages/arc-bpmn/cdk/common/stacks/lambda.stack.ts
@@ -1,8 +1,9 @@
 import * as random from '@cdktf/provider-random';
+import {ILambdaWithApiGateway, LambdaWithApiGateway} from 'arc-cdk';
 import {TerraformStack} from 'cdktf';
 import {Construct} from 'constructs';
-import {ILambdaWithApiGateway, LambdaWithApiGateway} from 'arc-cdk';
 import {AwsProvider} from '../constructs/awsProvider';
+import path = require('path');
 
 export class LambdaStack extends TerraformStack {
   constructor(
@@ -20,7 +21,10 @@ export class LambdaStack extends TerraformStack {
       length: 2,
     });
 
-    new LambdaWithApiGateway(this, 'lambda-apiGateway', {// NOSONAR
+    // overwrite codePath based on useImage as deploy via docker needs different codePath
+    config.codePath = path.resolve(config.codePath, `../${config.useImage ? '' : 'dist'}`);
+
+    new LambdaWithApiGateway(this, 'lambda-apiGateway', {
       ...config,
       name: pet.id,
     });

--- a/packages/arc-bpmn/cdk/common/stacks/lambda.stack.ts
+++ b/packages/arc-bpmn/cdk/common/stacks/lambda.stack.ts
@@ -24,7 +24,7 @@ export class LambdaStack extends TerraformStack {
     // overwrite codePath based on useImage as deploy via docker needs different codePath
     config.codePath = path.resolve(config.codePath, `../${config.useImage ? '' : 'dist'}`);
 
-    new LambdaWithApiGateway(this, 'lambda-apiGateway', {
+    new LambdaWithApiGateway(this, 'lambda-apiGateway', {// NOSONAR
       ...config,
       name: pet.id,
     });

--- a/packages/arc-bpmn/cdk/main.ts
+++ b/packages/arc-bpmn/cdk/main.ts
@@ -57,7 +57,7 @@ new MigrationStack(app, "migration", {// NOSONAR
 
 new LambdaStack(app, "lambda", {// NOSONAR
   s3Bucket: process.env.S3_BUCKET!,
-  codePath: resolve(__dirname, "../dist"),
+  codePath: __dirname,
   handler: "lambda.handler",
   runtime: "nodejs16.x",
   layerPath: resolve(__dirname, "../layers"),
@@ -86,6 +86,7 @@ new LambdaStack(app, "lambda", {// NOSONAR
   },
   namespace: process.env.NAMESPACE || "",
   environment: process.env.ENV || "",
+  useImage: true,
 });
 
 app.synth();

--- a/packages/arc-bpmn/cdk/main.ts
+++ b/packages/arc-bpmn/cdk/main.ts
@@ -36,7 +36,7 @@ const getSecurityGroup = () => {
 new MigrationStack(app, "migration", {// NOSONAR
   codePath: resolve(__dirname, "../migration"),
   handler: "lambda.handler",
-  runtime: "nodejs16.x",
+  runtime: "nodejs18.x",
   vpcConfig: {
     securityGroupIds: getSecurityGroup(),
     subnetIds: getSubnetIds(),
@@ -59,7 +59,7 @@ new LambdaStack(app, "lambda", {// NOSONAR
   s3Bucket: process.env.S3_BUCKET!,
   codePath: __dirname,
   handler: "lambda.handler",
-  runtime: "nodejs16.x",
+  runtime: "nodejs18.x",
   layerPath: resolve(__dirname, "../layers"),
   vpcConfig: {
     securityGroupIds: getSecurityGroup(),

--- a/packages/arc-bpmn/cdk/package.json
+++ b/packages/arc-bpmn/cdk/package.json
@@ -28,6 +28,7 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@cdktf/provider-aws": "12.0.8"
+    "@cdktf/provider-aws": "12.0.8",
+    "arc-cdk": "^0.0.8"
   }
 }

--- a/packages/arc-feature-toggle/Dockerfile
+++ b/packages/arc-feature-toggle/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR ${LAMBDA_TASK_ROOT}
 # Install app dependencies
 COPY package*.json ./
 
-RUN npm install --ignore-scripts
+RUN npm install
 
 # Bundle app source code
 COPY . .
@@ -17,4 +17,4 @@ COPY . .
 # Build Loopback app
 RUN npm run build
 
-CMD [ "./dist/main.handler" ]
+CMD [ "./dist/lambda.handler" ]

--- a/packages/arc-feature-toggle/Dockerfile
+++ b/packages/arc-feature-toggle/Dockerfile
@@ -1,5 +1,5 @@
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:16 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}

--- a/packages/arc-feature-toggle/cdk/common/stacks/lambda.stack.ts
+++ b/packages/arc-feature-toggle/cdk/common/stacks/lambda.stack.ts
@@ -1,8 +1,9 @@
 import * as random from '@cdktf/provider-random';
+import {ILambdaWithApiGateway, LambdaWithApiGateway} from 'arc-cdk';
 import {TerraformStack} from 'cdktf';
 import {Construct} from 'constructs';
-import {ILambdaWithApiGateway, LambdaWithApiGateway} from 'arc-cdk';
 import {AwsProvider} from '../constructs/awsProvider';
+import path = require('path');
 
 export class LambdaStack extends TerraformStack {
   constructor(
@@ -19,8 +20,10 @@ export class LambdaStack extends TerraformStack {
     const pet = new random.pet.Pet(this, 'random-name', {
       length: 2,
     });
+    // overwrite codePath based on useImage as deploy via docker needs different codePath
+    config.codePath = path.resolve(config.codePath, `../${config.useImage ? '' : 'dist'}`);
 
-    new LambdaWithApiGateway(this, 'lambda-apiGateway', {// NOSONAR
+    new LambdaWithApiGateway(this, 'lambda-apiGateway', {
       ...config,
       name: pet.id,
     });

--- a/packages/arc-feature-toggle/cdk/common/stacks/lambda.stack.ts
+++ b/packages/arc-feature-toggle/cdk/common/stacks/lambda.stack.ts
@@ -23,7 +23,7 @@ export class LambdaStack extends TerraformStack {
     // overwrite codePath based on useImage as deploy via docker needs different codePath
     config.codePath = path.resolve(config.codePath, `../${config.useImage ? '' : 'dist'}`);
 
-    new LambdaWithApiGateway(this, 'lambda-apiGateway', {
+    new LambdaWithApiGateway(this, 'lambda-apiGateway', {// NOSONAR
       ...config,
       name: pet.id,
     });

--- a/packages/arc-feature-toggle/cdk/main.ts
+++ b/packages/arc-feature-toggle/cdk/main.ts
@@ -42,7 +42,7 @@ new MigrationStack(app, 'migration', {// NOSONAR
 
 new LambdaStack(app, 'lambda', {// NOSONAR
   s3Bucket: process.env.S3_BUCKET!,
-  codePath: resolve(__dirname, '../dist'),
+  codePath: __dirname,
   handler: 'lambda.handler',
   runtime: 'nodejs16.x',
   layerPath: resolve(__dirname, '../layers'),
@@ -71,6 +71,7 @@ new LambdaStack(app, 'lambda', {// NOSONAR
   },
   namespace: process.env.NAMESPACE || '',
   environment: process.env.ENV || '',
+  useImage: true,
 });
 
 app.synth();

--- a/packages/arc-feature-toggle/cdk/main.ts
+++ b/packages/arc-feature-toggle/cdk/main.ts
@@ -21,7 +21,7 @@ const app = new App();
 new MigrationStack(app, 'migration', {// NOSONAR
   codePath: resolve(__dirname, '../migration'),
   handler: 'lambda.handler',
-  runtime: 'nodejs16.x',
+  runtime: 'nodejs18.x',
   vpcConfig: {
     securityGroupIds: getSecurityGroup(),
     subnetIds: getSubnetIds(),
@@ -44,7 +44,7 @@ new LambdaStack(app, 'lambda', {// NOSONAR
   s3Bucket: process.env.S3_BUCKET!,
   codePath: __dirname,
   handler: 'lambda.handler',
-  runtime: 'nodejs16.x',
+  runtime: 'nodejs18.x',
   layerPath: resolve(__dirname, '../layers'),
   vpcConfig: {
     securityGroupIds: getSecurityGroup(),

--- a/packages/arc-feature-toggle/cdk/package.json
+++ b/packages/arc-feature-toggle/cdk/package.json
@@ -26,7 +26,7 @@
     "@cdktf/provider-random": "^5.0.0",
     "cdktf": "^0.15.5",
     "constructs": "^10.1.257",
-    "arc-cdk": "^0.0.3"
+    "arc-cdk": "^0.0.8"
   },
   "devDependencies": {
     "@types/jest": "^29.4.0",

--- a/packages/arc-in-mail/Dockerfile
+++ b/packages/arc-in-mail/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR ${LAMBDA_TASK_ROOT}
 # Install app dependencies
 COPY package*.json ./
 
-RUN npm install --ignore-scripts
+RUN npm install
 
 # Bundle app source code
 COPY . .
@@ -17,4 +17,4 @@ COPY . .
 # Build Loopback app
 RUN npm run build
 
-CMD [ "./dist/main.handler" ]
+CMD [ "./dist/lambda.handler" ]

--- a/packages/arc-in-mail/Dockerfile
+++ b/packages/arc-in-mail/Dockerfile
@@ -1,5 +1,5 @@
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:16 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}

--- a/packages/arc-in-mail/cdk/__tests__/lambda.stack.test.ts
+++ b/packages/arc-in-mail/cdk/__tests__/lambda.stack.test.ts
@@ -1,21 +1,21 @@
 // https://cdk.tf/testing
-import { AcmCertificate } from '@cdktf/provider-aws/lib/acm-certificate';
-import { AcmCertificateValidation } from '@cdktf/provider-aws/lib/acm-certificate-validation';
-import { Apigatewayv2Api } from '@cdktf/provider-aws/lib/apigatewayv2-api';
-import { Apigatewayv2ApiMapping } from '@cdktf/provider-aws/lib/apigatewayv2-api-mapping';
-import { Apigatewayv2DomainName } from '@cdktf/provider-aws/lib/apigatewayv2-domain-name';
-import { IamPolicy } from '@cdktf/provider-aws/lib/iam-policy';
-import { IamRole } from '@cdktf/provider-aws/lib/iam-role';
-import { IamRolePolicyAttachment } from '@cdktf/provider-aws/lib/iam-role-policy-attachment';
-import { LambdaFunction } from '@cdktf/provider-aws/lib/lambda-function';
-import { LambdaLayerVersion } from '@cdktf/provider-aws/lib/lambda-layer-version';
-import { LambdaPermission } from '@cdktf/provider-aws/lib/lambda-permission';
-import { Route53Record } from '@cdktf/provider-aws/lib/route53-record';
-import { Pet } from '@cdktf/provider-random/lib/pet';
-import { Testing } from 'cdktf';
+import {AcmCertificate} from '@cdktf/provider-aws/lib/acm-certificate';
+import {AcmCertificateValidation} from '@cdktf/provider-aws/lib/acm-certificate-validation';
+import {Apigatewayv2Api} from '@cdktf/provider-aws/lib/apigatewayv2-api';
+import {Apigatewayv2ApiMapping} from '@cdktf/provider-aws/lib/apigatewayv2-api-mapping';
+import {Apigatewayv2DomainName} from '@cdktf/provider-aws/lib/apigatewayv2-domain-name';
+import {IamPolicy} from '@cdktf/provider-aws/lib/iam-policy';
+import {IamRole} from '@cdktf/provider-aws/lib/iam-role';
+import {IamRolePolicyAttachment} from '@cdktf/provider-aws/lib/iam-role-policy-attachment';
+import {LambdaFunction} from '@cdktf/provider-aws/lib/lambda-function';
+import {LambdaLayerVersion} from '@cdktf/provider-aws/lib/lambda-layer-version';
+import {LambdaPermission} from '@cdktf/provider-aws/lib/lambda-permission';
+import {Route53Record} from '@cdktf/provider-aws/lib/route53-record';
+import {Pet} from '@cdktf/provider-random/lib/pet';
+import {Testing} from 'cdktf';
 import 'cdktf/lib/testing/adapters/jest'; // Load types for expect matchers
-import { LambdaFunctionConfig, LambdaStack } from '../common';
-import { defaultLambdaMemory } from '../common/utils/constants';
+import {LambdaFunctionConfig, LambdaStack} from '../common';
+import {defaultLambdaMemory} from '../common/utils/constants';
 
 expect.addSnapshotSerializer({
   test: val => typeof val === 'string',
@@ -29,7 +29,7 @@ expect.addSnapshotSerializer({
 });
 
 const handler = 'lambda.handler';
-const runtime = 'nodejs16.x';
+const runtime = 'nodejs18.x';
 const version = 'v0.0.1';
 const subnetIds = ['subnet-123456'];
 const securityGroupIds = ['sg-123456'];

--- a/packages/arc-in-mail/cdk/common/stacks/lambda.stack.ts
+++ b/packages/arc-in-mail/cdk/common/stacks/lambda.stack.ts
@@ -1,8 +1,9 @@
 import * as random from '@cdktf/provider-random';
+import {ILambdaWithApiGateway, LambdaWithApiGateway} from 'arc-cdk';
 import {TerraformStack} from 'cdktf';
 import {Construct} from 'constructs';
-import {ILambdaWithApiGateway, LambdaWithApiGateway} from 'arc-cdk';
 import {AwsProvider} from '../constructs/awsProvider';
+import path = require('path');
 
 export class LambdaStack extends TerraformStack {
   constructor(
@@ -20,7 +21,10 @@ export class LambdaStack extends TerraformStack {
       length: 2,
     });
 
-    new LambdaWithApiGateway(this, 'lambda-apiGateway', {// NOSONAR
+    // overwrite codePath based on useImage as deploy via docker needs different codePath
+    config.codePath = path.resolve(config.codePath, `../${config.useImage ? '' : 'dist'}`);
+
+    new LambdaWithApiGateway(this, 'lambda-apiGateway', {
       ...config,
       name: pet.id,
     });

--- a/packages/arc-in-mail/cdk/common/stacks/lambda.stack.ts
+++ b/packages/arc-in-mail/cdk/common/stacks/lambda.stack.ts
@@ -24,7 +24,7 @@ export class LambdaStack extends TerraformStack {
     // overwrite codePath based on useImage as deploy via docker needs different codePath
     config.codePath = path.resolve(config.codePath, `../${config.useImage ? '' : 'dist'}`);
 
-    new LambdaWithApiGateway(this, 'lambda-apiGateway', {
+    new LambdaWithApiGateway(this, 'lambda-apiGateway', {// NOSONAR
       ...config,
       name: pet.id,
     });

--- a/packages/arc-in-mail/cdk/main.ts
+++ b/packages/arc-in-mail/cdk/main.ts
@@ -36,7 +36,7 @@ const getSecurityGroup = () => {
 new MigrationStack(app, 'migration', {// NOSONAR
   codePath: resolve(__dirname, '../migration'),
   handler: 'lambda.handler',
-  runtime: 'nodejs16.x',
+  runtime: 'nodejs18.x',
   vpcConfig: {
     securityGroupIds: getSecurityGroup(),
     subnetIds: getSubnetIds(),
@@ -59,7 +59,7 @@ new LambdaStack(app, 'lambda', {// NOSONAR
   s3Bucket: process.env.S3_BUCKET!,
   codePath: __dirname,
   handler: 'lambda.handler',
-  runtime: 'nodejs16.x',
+  runtime: 'nodejs18.x',
   layerPath: resolve(__dirname, '../layers'),
   vpcConfig: {
     securityGroupIds: getSecurityGroup(),

--- a/packages/arc-in-mail/cdk/main.ts
+++ b/packages/arc-in-mail/cdk/main.ts
@@ -57,7 +57,7 @@ new MigrationStack(app, 'migration', {// NOSONAR
 
 new LambdaStack(app, 'lambda', {// NOSONAR
   s3Bucket: process.env.S3_BUCKET!,
-  codePath: resolve(__dirname, '../dist'),
+  codePath: __dirname,
   handler: 'lambda.handler',
   runtime: 'nodejs16.x',
   layerPath: resolve(__dirname, '../layers'),
@@ -86,6 +86,7 @@ new LambdaStack(app, 'lambda', {// NOSONAR
   },
   namespace: process.env.NAMESPACE || '',
   environment: process.env.ENV || '',
+  useImage: true,
 });
 
 app.synth();

--- a/packages/arc-in-mail/cdk/package.json
+++ b/packages/arc-in-mail/cdk/package.json
@@ -29,7 +29,7 @@
     "constructs": "^10.1.229",
     "dotenv": "^16.0.3",
     "dotenv-extended": "^2.9.0",
-    "arc-cdk": "^0.0.3"
+    "arc-cdk": "^0.0.8"
   },
   "devDependencies": {
     "@types/jest": "^29.2.6",

--- a/packages/arc-payment/Dockerfile
+++ b/packages/arc-payment/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR ${LAMBDA_TASK_ROOT}
 # Install app dependencies
 COPY package*.json ./
 
-RUN npm install --ignore-scripts
+RUN npm install
 
 # Bundle app source code
 COPY . .
@@ -17,4 +17,4 @@ COPY . .
 # Build Loopback app
 RUN npm run build
 
-CMD [ "./dist/main.handler" ]
+CMD [ "./dist/lambda.handler" ]

--- a/packages/arc-payment/Dockerfile
+++ b/packages/arc-payment/Dockerfile
@@ -1,5 +1,5 @@
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:16 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}

--- a/packages/arc-payment/cdk/__tests__/lambda.stack.test.ts
+++ b/packages/arc-payment/cdk/__tests__/lambda.stack.test.ts
@@ -1,21 +1,21 @@
 // https://cdk.tf/testing
-import { AcmCertificate } from '@cdktf/provider-aws/lib/acm-certificate';
-import { AcmCertificateValidation } from '@cdktf/provider-aws/lib/acm-certificate-validation';
-import { Apigatewayv2Api } from '@cdktf/provider-aws/lib/apigatewayv2-api';
-import { Apigatewayv2ApiMapping } from '@cdktf/provider-aws/lib/apigatewayv2-api-mapping';
-import { Apigatewayv2DomainName } from '@cdktf/provider-aws/lib/apigatewayv2-domain-name';
-import { IamPolicy } from '@cdktf/provider-aws/lib/iam-policy';
-import { IamRole } from '@cdktf/provider-aws/lib/iam-role';
-import { IamRolePolicyAttachment } from '@cdktf/provider-aws/lib/iam-role-policy-attachment';
-import { LambdaFunction } from '@cdktf/provider-aws/lib/lambda-function';
-import { LambdaLayerVersion } from '@cdktf/provider-aws/lib/lambda-layer-version';
-import { LambdaPermission } from '@cdktf/provider-aws/lib/lambda-permission';
-import { Route53Record } from '@cdktf/provider-aws/lib/route53-record';
-import { Pet } from '@cdktf/provider-random/lib/pet';
-import { Testing } from 'cdktf';
+import {AcmCertificate} from '@cdktf/provider-aws/lib/acm-certificate';
+import {AcmCertificateValidation} from '@cdktf/provider-aws/lib/acm-certificate-validation';
+import {Apigatewayv2Api} from '@cdktf/provider-aws/lib/apigatewayv2-api';
+import {Apigatewayv2ApiMapping} from '@cdktf/provider-aws/lib/apigatewayv2-api-mapping';
+import {Apigatewayv2DomainName} from '@cdktf/provider-aws/lib/apigatewayv2-domain-name';
+import {IamPolicy} from '@cdktf/provider-aws/lib/iam-policy';
+import {IamRole} from '@cdktf/provider-aws/lib/iam-role';
+import {IamRolePolicyAttachment} from '@cdktf/provider-aws/lib/iam-role-policy-attachment';
+import {LambdaFunction} from '@cdktf/provider-aws/lib/lambda-function';
+import {LambdaLayerVersion} from '@cdktf/provider-aws/lib/lambda-layer-version';
+import {LambdaPermission} from '@cdktf/provider-aws/lib/lambda-permission';
+import {Route53Record} from '@cdktf/provider-aws/lib/route53-record';
+import {Pet} from '@cdktf/provider-random/lib/pet';
+import {Testing} from 'cdktf';
 import 'cdktf/lib/testing/adapters/jest'; // Load types for expect matchers
-import { LambdaFunctionConfig, LambdaStack } from '../common';
-import { defaultLambdaMemory } from '../common/utils/constants';
+import {LambdaFunctionConfig, LambdaStack} from '../common';
+import {defaultLambdaMemory} from '../common/utils/constants';
 
 expect.addSnapshotSerializer({
   test: val => typeof val === 'string',
@@ -29,7 +29,7 @@ expect.addSnapshotSerializer({
 });
 
 const handler = 'lambda.handler';
-const runtime = 'nodejs16.x';
+const runtime = 'nodejs18.x';
 const version = 'v0.0.1';
 const subnetIds = ['subnet-123456'];
 const securityGroupIds = ['sg-123456'];

--- a/packages/arc-payment/cdk/common/stacks/lambda.stack.ts
+++ b/packages/arc-payment/cdk/common/stacks/lambda.stack.ts
@@ -1,8 +1,9 @@
 import * as random from '@cdktf/provider-random';
+import {ILambdaWithApiGateway, LambdaWithApiGateway} from 'arc-cdk';
 import {TerraformStack} from 'cdktf';
 import {Construct} from 'constructs';
-import {ILambdaWithApiGateway, LambdaWithApiGateway} from 'arc-cdk';
 import {AwsProvider} from '../constructs/awsProvider';
+import path = require('path');
 
 export class LambdaStack extends TerraformStack {
   constructor(
@@ -20,7 +21,10 @@ export class LambdaStack extends TerraformStack {
       length: 2,
     });
 
-    new LambdaWithApiGateway(this, 'lambda-apiGateway', {// NOSONAR
+    // overwrite codePath based on useImage as deploy via docker needs different codePath
+    config.codePath = path.resolve(config.codePath, `../${config.useImage ? '' : 'dist'}`);
+
+    new LambdaWithApiGateway(this, 'lambda-apiGateway', {
       ...config,
       name: pet.id,
     });

--- a/packages/arc-payment/cdk/common/stacks/lambda.stack.ts
+++ b/packages/arc-payment/cdk/common/stacks/lambda.stack.ts
@@ -24,7 +24,7 @@ export class LambdaStack extends TerraformStack {
     // overwrite codePath based on useImage as deploy via docker needs different codePath
     config.codePath = path.resolve(config.codePath, `../${config.useImage ? '' : 'dist'}`);
 
-    new LambdaWithApiGateway(this, 'lambda-apiGateway', {
+    new LambdaWithApiGateway(this, 'lambda-apiGateway', {// NOSONAR
       ...config,
       name: pet.id,
     });

--- a/packages/arc-payment/cdk/main.ts
+++ b/packages/arc-payment/cdk/main.ts
@@ -42,7 +42,7 @@ new MigrationStack(app, 'migration', {// NOSONAR
 
 new LambdaStack(app, 'lambda', {// NOSONAR
   s3Bucket: process.env.S3_BUCKET!,
-  codePath: resolve(__dirname, '../dist'),
+  codePath: __dirname,
   handler: 'lambda.handler',
   runtime: 'nodejs16.x',
   layerPath: resolve(__dirname, '../layers'),
@@ -71,6 +71,7 @@ new LambdaStack(app, 'lambda', {// NOSONAR
   },
   namespace: process.env.NAMESPACE || '',
   environment: process.env.ENV || '',
+  useImage: true,
 });
 
 app.synth();

--- a/packages/arc-payment/cdk/main.ts
+++ b/packages/arc-payment/cdk/main.ts
@@ -21,7 +21,7 @@ const app = new App();
 new MigrationStack(app, 'migration', {// NOSONAR
   codePath: resolve(__dirname, '../migration'),
   handler: 'lambda.handler',
-  runtime: 'nodejs16.x',
+  runtime: 'nodejs18.x',
   vpcConfig: {
     securityGroupIds: getSecurityGroup(),
     subnetIds: getSubnetIds(),
@@ -44,7 +44,7 @@ new LambdaStack(app, 'lambda', {// NOSONAR
   s3Bucket: process.env.S3_BUCKET!,
   codePath: __dirname,
   handler: 'lambda.handler',
-  runtime: 'nodejs16.x',
+  runtime: 'nodejs18.x',
   layerPath: resolve(__dirname, '../layers'),
   vpcConfig: {
     securityGroupIds: getSecurityGroup(),

--- a/packages/arc-payment/cdk/package.json
+++ b/packages/arc-payment/cdk/package.json
@@ -29,7 +29,7 @@
     "constructs": "^10.1.229",
     "dotenv": "^16.0.3",
     "dotenv-extended": "^2.9.0",
-    "arc-cdk": "^0.0.3"
+    "arc-cdk": "^0.0.8"
   },
   "devDependencies": {
     "@types/jest": "^29.2.6",

--- a/packages/arc-scheduler/Dockerfile
+++ b/packages/arc-scheduler/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR ${LAMBDA_TASK_ROOT}
 # Install app dependencies
 COPY package*.json ./
 
-RUN npm install --ignore-scripts
+RUN npm install
 
 # Bundle app source code
 COPY . .
@@ -17,4 +17,4 @@ COPY . .
 # Build Loopback app
 RUN npm run build
 
-CMD [ "./dist/main.handler" ]
+CMD [ "./dist/lambda.handler" ]

--- a/packages/arc-scheduler/Dockerfile
+++ b/packages/arc-scheduler/Dockerfile
@@ -1,5 +1,5 @@
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:16 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}

--- a/packages/arc-scheduler/cdk/common/stacks/lambda.stack.ts
+++ b/packages/arc-scheduler/cdk/common/stacks/lambda.stack.ts
@@ -1,8 +1,9 @@
 import * as random from '@cdktf/provider-random';
+import {ILambdaWithApiGateway, LambdaWithApiGateway} from 'arc-cdk';
 import {TerraformStack} from 'cdktf';
 import {Construct} from 'constructs';
-import {ILambdaWithApiGateway, LambdaWithApiGateway} from 'arc-cdk';
 import {AwsProvider} from '../constructs/awsProvider';
+import path = require('path');
 
 export class LambdaStack extends TerraformStack {
   constructor(
@@ -20,7 +21,10 @@ export class LambdaStack extends TerraformStack {
       length: 2,
     });
 
-    new LambdaWithApiGateway(this, 'lambda-apiGateway', {// NOSONAR
+    // overwrite codePath based on useImage as deploy via docker needs different codePath
+    config.codePath = path.resolve(config.codePath, `../${config.useImage ? '' : 'dist'}`);
+
+    new LambdaWithApiGateway(this, 'lambda-apiGateway', {
       ...config,
       name: pet.id,
     });

--- a/packages/arc-scheduler/cdk/common/stacks/lambda.stack.ts
+++ b/packages/arc-scheduler/cdk/common/stacks/lambda.stack.ts
@@ -24,7 +24,7 @@ export class LambdaStack extends TerraformStack {
     // overwrite codePath based on useImage as deploy via docker needs different codePath
     config.codePath = path.resolve(config.codePath, `../${config.useImage ? '' : 'dist'}`);
 
-    new LambdaWithApiGateway(this, 'lambda-apiGateway', {
+    new LambdaWithApiGateway(this, 'lambda-apiGateway', {// NOSONAR
       ...config,
       name: pet.id,
     });

--- a/packages/arc-scheduler/cdk/main.ts
+++ b/packages/arc-scheduler/cdk/main.ts
@@ -36,7 +36,7 @@ const getSecurityGroup = () => {
 new MigrationStack(app, "migration", {// NOSONAR
   codePath: resolve(__dirname, "../migration"),
   handler: "lambda.handler",
-  runtime: "nodejs16.x",
+  runtime: "nodejs18.x",
   vpcConfig: {
     securityGroupIds: getSecurityGroup(),
     subnetIds: getSubnetIds(),
@@ -58,7 +58,7 @@ new MigrationStack(app, "migration", {// NOSONAR
 new LambdaStack(app, "lambda", {// NOSONAR
   codePath: __dirname,
   handler: "lambda.handler",
-  runtime: "nodejs16.x",
+  runtime: "nodejs18.x",
   layerPath: resolve(__dirname, "../layers"),
   vpcConfig: {
     securityGroupIds: getSecurityGroup(),

--- a/packages/arc-scheduler/cdk/main.ts
+++ b/packages/arc-scheduler/cdk/main.ts
@@ -56,7 +56,7 @@ new MigrationStack(app, "migration", {// NOSONAR
 });
 
 new LambdaStack(app, "lambda", {// NOSONAR
-  codePath: resolve(__dirname, "../dist"),
+  codePath: __dirname,
   handler: "lambda.handler",
   runtime: "nodejs16.x",
   layerPath: resolve(__dirname, "../layers"),
@@ -86,6 +86,7 @@ new LambdaStack(app, "lambda", {// NOSONAR
   namespace: process.env.NAMESPACE || "",
   environment: process.env.ENV || "",
   s3Bucket: process.env.S3_BUCKET!,
+  useImage: true,
 });
 
 app.synth();

--- a/packages/arc-scheduler/cdk/package.json
+++ b/packages/arc-scheduler/cdk/package.json
@@ -26,7 +26,7 @@
     "constructs": "^10.1.229",
     "dotenv": "^16.0.3",
     "dotenv-extended": "^2.9.0",
-    "arc-cdk": "^0.0.3"
+    "arc-cdk": "^0.0.8"
   },
   "devDependencies": {
     "@types/jest": "^29.2.6",

--- a/packages/arc-search/Dockerfile
+++ b/packages/arc-search/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR ${LAMBDA_TASK_ROOT}
 # Install app dependencies
 COPY package*.json ./
 
-RUN npm install --ignore-scripts
+RUN npm install
 
 # Bundle app source code
 COPY . .
@@ -17,4 +17,4 @@ COPY . .
 # Build Loopback app
 RUN npm run build
 
-CMD [ "./dist/main.handler" ]
+CMD [ "./dist/lambda.handler" ]

--- a/packages/arc-search/Dockerfile
+++ b/packages/arc-search/Dockerfile
@@ -1,5 +1,5 @@
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:16 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}

--- a/packages/arc-search/cdk/__tests__/lambda.stack.test.ts
+++ b/packages/arc-search/cdk/__tests__/lambda.stack.test.ts
@@ -1,21 +1,21 @@
 // https://cdk.tf/testing
-import { AcmCertificate } from '@cdktf/provider-aws/lib/acm-certificate';
-import { AcmCertificateValidation } from '@cdktf/provider-aws/lib/acm-certificate-validation';
-import { Apigatewayv2Api } from '@cdktf/provider-aws/lib/apigatewayv2-api';
-import { Apigatewayv2ApiMapping } from '@cdktf/provider-aws/lib/apigatewayv2-api-mapping';
-import { Apigatewayv2DomainName } from '@cdktf/provider-aws/lib/apigatewayv2-domain-name';
-import { IamPolicy } from '@cdktf/provider-aws/lib/iam-policy';
-import { IamRole } from '@cdktf/provider-aws/lib/iam-role';
-import { IamRolePolicyAttachment } from '@cdktf/provider-aws/lib/iam-role-policy-attachment';
-import { LambdaFunction } from '@cdktf/provider-aws/lib/lambda-function';
-import { LambdaLayerVersion } from '@cdktf/provider-aws/lib/lambda-layer-version';
-import { LambdaPermission } from '@cdktf/provider-aws/lib/lambda-permission';
-import { Route53Record } from '@cdktf/provider-aws/lib/route53-record';
-import { Pet } from '@cdktf/provider-random/lib/pet';
-import { Testing } from 'cdktf';
+import {AcmCertificate} from '@cdktf/provider-aws/lib/acm-certificate';
+import {AcmCertificateValidation} from '@cdktf/provider-aws/lib/acm-certificate-validation';
+import {Apigatewayv2Api} from '@cdktf/provider-aws/lib/apigatewayv2-api';
+import {Apigatewayv2ApiMapping} from '@cdktf/provider-aws/lib/apigatewayv2-api-mapping';
+import {Apigatewayv2DomainName} from '@cdktf/provider-aws/lib/apigatewayv2-domain-name';
+import {IamPolicy} from '@cdktf/provider-aws/lib/iam-policy';
+import {IamRole} from '@cdktf/provider-aws/lib/iam-role';
+import {IamRolePolicyAttachment} from '@cdktf/provider-aws/lib/iam-role-policy-attachment';
+import {LambdaFunction} from '@cdktf/provider-aws/lib/lambda-function';
+import {LambdaLayerVersion} from '@cdktf/provider-aws/lib/lambda-layer-version';
+import {LambdaPermission} from '@cdktf/provider-aws/lib/lambda-permission';
+import {Route53Record} from '@cdktf/provider-aws/lib/route53-record';
+import {Pet} from '@cdktf/provider-random/lib/pet';
+import {Testing} from 'cdktf';
 import 'cdktf/lib/testing/adapters/jest'; // Load types for expect matchers
-import { LambdaFunctionConfig, LambdaStack } from '../common';
-import { defaultLambdaMemory } from '../common/utils/constants';
+import {LambdaFunctionConfig, LambdaStack} from '../common';
+import {defaultLambdaMemory} from '../common/utils/constants';
 
 expect.addSnapshotSerializer({
   test: val => typeof val === 'string',
@@ -29,7 +29,7 @@ expect.addSnapshotSerializer({
 });
 
 const handler = 'lambda.handler';
-const runtime = 'nodejs16.x';
+const runtime = 'nodejs18.x';
 const version = 'v0.0.1';
 const subnetIds = ['subnet-123456'];
 const securityGroupIds = ['sg-123456'];

--- a/packages/arc-search/cdk/common/stacks/lambda.stack.ts
+++ b/packages/arc-search/cdk/common/stacks/lambda.stack.ts
@@ -1,8 +1,9 @@
 import * as random from '@cdktf/provider-random';
+import {ILambdaWithApiGateway, LambdaWithApiGateway} from 'arc-cdk';
 import {TerraformStack} from 'cdktf';
 import {Construct} from 'constructs';
-import {ILambdaWithApiGateway, LambdaWithApiGateway} from 'arc-cdk';
 import {AwsProvider} from '../constructs/awsProvider';
+import path = require('path');
 
 export class LambdaStack extends TerraformStack {
   constructor(
@@ -20,7 +21,10 @@ export class LambdaStack extends TerraformStack {
       length: 2,
     });
 
-    new LambdaWithApiGateway(this, 'lambda-apiGateway', {// NOSONAR
+    // overwrite codePath based on useImage as deploy via docker needs different codePath
+    config.codePath = path.resolve(config.codePath, `../${config.useImage ? '' : 'dist'}`);
+
+    new LambdaWithApiGateway(this, 'lambda-apiGateway', {
       ...config,
       name: pet.id,
     });

--- a/packages/arc-search/cdk/common/stacks/lambda.stack.ts
+++ b/packages/arc-search/cdk/common/stacks/lambda.stack.ts
@@ -24,7 +24,7 @@ export class LambdaStack extends TerraformStack {
     // overwrite codePath based on useImage as deploy via docker needs different codePath
     config.codePath = path.resolve(config.codePath, `../${config.useImage ? '' : 'dist'}`);
 
-    new LambdaWithApiGateway(this, 'lambda-apiGateway', {
+    new LambdaWithApiGateway(this, 'lambda-apiGateway', {// NOSONAR
       ...config,
       name: pet.id,
     });

--- a/packages/arc-search/cdk/main.ts
+++ b/packages/arc-search/cdk/main.ts
@@ -36,7 +36,7 @@ const getSecurityGroup = () => {
 new MigrationStack(app, 'migration', {// NOSONAR
   codePath: resolve(__dirname, '../migration'),
   handler: 'lambda.handler',
-  runtime: 'nodejs16.x',
+  runtime: 'nodejs18.x',
   vpcConfig: {
     securityGroupIds: getSecurityGroup(),
     subnetIds: getSubnetIds(),
@@ -59,7 +59,7 @@ new LambdaStack(app, 'lambda', {// NOSONAR
   s3Bucket: process.env.S3_BUCKET!,
   codePath: __dirname,
   handler: 'lambda.handler',
-  runtime: 'nodejs16.x',
+  runtime: 'nodejs18.x',
   layerPath: resolve(__dirname, '../layers'),
   vpcConfig: {
     securityGroupIds: getSecurityGroup(),

--- a/packages/arc-search/cdk/main.ts
+++ b/packages/arc-search/cdk/main.ts
@@ -57,7 +57,7 @@ new MigrationStack(app, 'migration', {// NOSONAR
 
 new LambdaStack(app, 'lambda', {// NOSONAR
   s3Bucket: process.env.S3_BUCKET!,
-  codePath: resolve(__dirname, '../dist'),
+  codePath: __dirname,
   handler: 'lambda.handler',
   runtime: 'nodejs16.x',
   layerPath: resolve(__dirname, '../layers'),
@@ -86,6 +86,7 @@ new LambdaStack(app, 'lambda', {// NOSONAR
   },
   namespace: process.env.NAMESPACE || '',
   environment: process.env.ENV || '',
+  useImage: true,
 });
 
 app.synth();

--- a/packages/arc-search/cdk/package.json
+++ b/packages/arc-search/cdk/package.json
@@ -29,7 +29,7 @@
     "constructs": "^10.1.229",
     "dotenv": "^16.0.3",
     "dotenv-extended": "^2.9.0",
-    "arc-cdk": "^0.0.3"
+    "arc-cdk": "^0.0.8"
   },
   "devDependencies": {
     "@types/jest": "^29.2.6",

--- a/packages/arc-user-tenant/Dockerfile
+++ b/packages/arc-user-tenant/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR ${LAMBDA_TASK_ROOT}
 # Install app dependencies
 COPY package*.json ./
 
-RUN npm install --ignore-scripts
+RUN npm install
 
 # Bundle app source code
 COPY . .
@@ -17,4 +17,4 @@ COPY . .
 # Build Loopback app
 RUN npm run build
 
-CMD [ "./dist/main.handler" ]
+CMD [ "./dist/lambda.handler" ]

--- a/packages/arc-user-tenant/Dockerfile
+++ b/packages/arc-user-tenant/Dockerfile
@@ -1,5 +1,5 @@
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:16 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}

--- a/packages/arc-user-tenant/cdk/__tests__/lambda.stack.test.ts
+++ b/packages/arc-user-tenant/cdk/__tests__/lambda.stack.test.ts
@@ -1,21 +1,21 @@
 // https://cdk.tf/testing
-import { AcmCertificate } from '@cdktf/provider-aws/lib/acm-certificate';
-import { AcmCertificateValidation } from '@cdktf/provider-aws/lib/acm-certificate-validation';
-import { Apigatewayv2Api } from '@cdktf/provider-aws/lib/apigatewayv2-api';
-import { Apigatewayv2ApiMapping } from '@cdktf/provider-aws/lib/apigatewayv2-api-mapping';
-import { Apigatewayv2DomainName } from '@cdktf/provider-aws/lib/apigatewayv2-domain-name';
-import { IamPolicy } from '@cdktf/provider-aws/lib/iam-policy';
-import { IamRole } from '@cdktf/provider-aws/lib/iam-role';
-import { IamRolePolicyAttachment } from '@cdktf/provider-aws/lib/iam-role-policy-attachment';
-import { LambdaFunction } from '@cdktf/provider-aws/lib/lambda-function';
-import { LambdaLayerVersion } from '@cdktf/provider-aws/lib/lambda-layer-version';
-import { LambdaPermission } from '@cdktf/provider-aws/lib/lambda-permission';
-import { Route53Record } from '@cdktf/provider-aws/lib/route53-record';
-import { Pet } from '@cdktf/provider-random/lib/pet';
-import { Testing } from 'cdktf';
+import {AcmCertificate} from '@cdktf/provider-aws/lib/acm-certificate';
+import {AcmCertificateValidation} from '@cdktf/provider-aws/lib/acm-certificate-validation';
+import {Apigatewayv2Api} from '@cdktf/provider-aws/lib/apigatewayv2-api';
+import {Apigatewayv2ApiMapping} from '@cdktf/provider-aws/lib/apigatewayv2-api-mapping';
+import {Apigatewayv2DomainName} from '@cdktf/provider-aws/lib/apigatewayv2-domain-name';
+import {IamPolicy} from '@cdktf/provider-aws/lib/iam-policy';
+import {IamRole} from '@cdktf/provider-aws/lib/iam-role';
+import {IamRolePolicyAttachment} from '@cdktf/provider-aws/lib/iam-role-policy-attachment';
+import {LambdaFunction} from '@cdktf/provider-aws/lib/lambda-function';
+import {LambdaLayerVersion} from '@cdktf/provider-aws/lib/lambda-layer-version';
+import {LambdaPermission} from '@cdktf/provider-aws/lib/lambda-permission';
+import {Route53Record} from '@cdktf/provider-aws/lib/route53-record';
+import {Pet} from '@cdktf/provider-random/lib/pet';
+import {Testing} from 'cdktf';
 import 'cdktf/lib/testing/adapters/jest'; // Load types for expect matchers
-import { LambdaFunctionConfig, LambdaStack } from '../common';
-import { defaultLambdaMemory } from '../common/utils/constants';
+import {LambdaFunctionConfig, LambdaStack} from '../common';
+import {defaultLambdaMemory} from '../common/utils/constants';
 
 expect.addSnapshotSerializer({
   test: val => typeof val === 'string',
@@ -29,7 +29,7 @@ expect.addSnapshotSerializer({
 });
 
 const handler = 'lambda.handler';
-const runtime = 'nodejs16.x';
+const runtime = 'nodejs18.x';
 const version = 'v0.0.1';
 const subnetIds = ['subnet-123456'];
 const securityGroupIds = ['sg-123456'];

--- a/packages/arc-user-tenant/cdk/common/stacks/lambda.stack.ts
+++ b/packages/arc-user-tenant/cdk/common/stacks/lambda.stack.ts
@@ -1,8 +1,9 @@
 import * as random from '@cdktf/provider-random';
+import {ILambdaWithApiGateway, LambdaWithApiGateway} from 'arc-cdk';
 import {TerraformStack} from 'cdktf';
 import {Construct} from 'constructs';
-import {ILambdaWithApiGateway, LambdaWithApiGateway} from 'arc-cdk';
 import {AwsProvider} from '../constructs/awsProvider';
+import path = require('path');
 
 export class LambdaStack extends TerraformStack {
   constructor(
@@ -20,7 +21,10 @@ export class LambdaStack extends TerraformStack {
       length: 2,
     });
 
-    new LambdaWithApiGateway(this, 'lambda-apiGateway', {// NOSONAR
+    // overwrite codePath based on useImage as deploy via docker needs different codePath
+    config.codePath = path.resolve(config.codePath, `../${config.useImage ? '' : 'dist'}`);
+
+    new LambdaWithApiGateway(this, 'lambda-apiGateway', {
       ...config,
       name: pet.id,
     });

--- a/packages/arc-user-tenant/cdk/common/stacks/lambda.stack.ts
+++ b/packages/arc-user-tenant/cdk/common/stacks/lambda.stack.ts
@@ -24,7 +24,7 @@ export class LambdaStack extends TerraformStack {
     // overwrite codePath based on useImage as deploy via docker needs different codePath
     config.codePath = path.resolve(config.codePath, `../${config.useImage ? '' : 'dist'}`);
 
-    new LambdaWithApiGateway(this, 'lambda-apiGateway', {
+    new LambdaWithApiGateway(this, 'lambda-apiGateway', {// NOSONAR
       ...config,
       name: pet.id,
     });

--- a/packages/arc-user-tenant/cdk/main.ts
+++ b/packages/arc-user-tenant/cdk/main.ts
@@ -36,7 +36,7 @@ const getSecurityGroup = () => {
 new MigrationStack(app, 'migration', {// NOSONAR
   codePath: resolve(__dirname, '../migration'),
   handler: 'lambda.handler',
-  runtime: 'nodejs16.x',
+  runtime: 'nodejs18.x',
   vpcConfig: {
     securityGroupIds: getSecurityGroup(),
     subnetIds: getSubnetIds(),
@@ -59,7 +59,7 @@ new LambdaStack(app, 'lambda', {// NOSONAR
   s3Bucket: process.env.S3_BUCKET!,
   codePath: __dirname,
   handler: 'lambda.handler',
-  runtime: 'nodejs16.x',
+  runtime: 'nodejs18.x',
   layerPath: resolve(__dirname, '../layers'),
   vpcConfig: {
     securityGroupIds: getSecurityGroup(),

--- a/packages/arc-user-tenant/cdk/main.ts
+++ b/packages/arc-user-tenant/cdk/main.ts
@@ -57,7 +57,7 @@ new MigrationStack(app, 'migration', {// NOSONAR
 
 new LambdaStack(app, 'lambda', {// NOSONAR
   s3Bucket: process.env.S3_BUCKET!,
-  codePath: resolve(__dirname, '../dist'),
+  codePath: __dirname,
   handler: 'lambda.handler',
   runtime: 'nodejs16.x',
   layerPath: resolve(__dirname, '../layers'),
@@ -86,6 +86,7 @@ new LambdaStack(app, 'lambda', {// NOSONAR
   },
   namespace: process.env.NAMESPACE || '',
   environment: process.env.ENV || '',
+  useImage: true,
 });
 
 app.synth();

--- a/packages/arc-user-tenant/cdk/package.json
+++ b/packages/arc-user-tenant/cdk/package.json
@@ -29,7 +29,7 @@
     "constructs": "^10.1.229",
     "dotenv": "^16.0.3",
     "dotenv-extended": "^2.9.0",
-    "arc-cdk": "^0.0.3"
+    "arc-cdk": "^0.0.8"
   },
   "devDependencies": {
     "@types/jest": "^29.2.6",

--- a/packages/lambda-apigateway/cdk/main.ts
+++ b/packages/lambda-apigateway/cdk/main.ts
@@ -16,7 +16,7 @@ new LambdaStack(app, "api-gateway", { // NOSONAR
   codePath: resolve(__dirname, "../dist"),
   layerPath: resolve(__dirname, "../layers"),
   handler: "api-gateway.handler",
-  runtime: "nodejs16.x",
+  runtime: "nodejs18.x",
   namespace: process.env.NAMESPACE || "",
   environment: process.env.ENV || "",
 });

--- a/packages/lambda-cron/cdk/main.ts
+++ b/packages/lambda-cron/cdk/main.ts
@@ -1,8 +1,8 @@
-import { App } from "cdktf";
+import {App} from "cdktf";
 import * as dotenv from "dotenv";
 import * as dotenvExt from "dotenv-extended";
-import { resolve } from "path";
-import { LambdaStack } from "./src/lambda.stack";
+import {resolve} from "path";
+import {LambdaStack} from "./src/lambda.stack";
 
 dotenv.config();
 dotenvExt.load({
@@ -16,7 +16,7 @@ new LambdaStack(app, "cron", { // NOSONAR
   codePath: resolve(__dirname, "../dist"),
   layerPath: resolve(__dirname, "../layers"),
   handler: "cron.handler",
-  runtime: "nodejs16.x",
+  runtime: "nodejs18.x",
   namespace: process.env.NAMESPACE || "",
   environment: process.env.ENV || "",
   scheduleExpression: "rate(1 day)",

--- a/packages/lambda-elasticache/cdk/main.ts
+++ b/packages/lambda-elasticache/cdk/main.ts
@@ -1,8 +1,8 @@
-import { App } from "cdktf";
+import {App} from "cdktf";
 import * as dotenv from "dotenv";
 import * as dotenvExt from "dotenv-extended";
-import { resolve } from "path";
-import { LambdaStack } from "./src/lambda.stack";
+import {resolve} from "path";
+import {LambdaStack} from "./src/lambda.stack";
 
 dotenv.config();
 dotenvExt.load({
@@ -15,7 +15,7 @@ const app = new App();
 new LambdaStack(app, "elasticache", {// NOSONAR
   codePath: resolve(__dirname, "../dist"),
   layerPath: resolve(__dirname, "../layers"),
-  runtime: "nodejs16.x",
+  runtime: "nodejs18.x",
   namespace: process.env.NAMESPACE || "",
   environment: process.env.ENV || "",
   handler: "elasticache.handler",

--- a/packages/lambda-sns/cdk/main.ts
+++ b/packages/lambda-sns/cdk/main.ts
@@ -1,8 +1,8 @@
-import { App } from "cdktf";
+import {App} from "cdktf";
 import * as dotenv from "dotenv";
 import * as dotenvExt from "dotenv-extended";
-import { resolve } from "path";
-import { LambdaStack } from "./src/lambda.stack";
+import {resolve} from "path";
+import {LambdaStack} from "./src/lambda.stack";
 
 dotenv.config();
 dotenvExt.load({
@@ -16,7 +16,7 @@ new LambdaStack(app, "sns", {// NOSONAR
   codePath: resolve(__dirname, "../dist"),
   layerPath: resolve(__dirname, "../layers"),
   handler: "sns.handler",
-  runtime: "nodejs16.x",
+  runtime: "nodejs18.x",
   namespace: process.env.NAMESPACE || "",
   environment: process.env.ENV || "",
   kmsMasterKeyId: "alias/aws/sns",

--- a/packages/lambda-sqs/cdk/main.ts
+++ b/packages/lambda-sqs/cdk/main.ts
@@ -1,8 +1,8 @@
-import { App } from "cdktf";
+import {App} from "cdktf";
 import * as dotenv from "dotenv";
 import * as dotenvExt from "dotenv-extended";
-import { resolve } from "path";
-import { LambdaStack } from "./src/lambda.stack";
+import {resolve} from "path";
+import {LambdaStack} from "./src/lambda.stack";
 
 dotenv.config();
 dotenvExt.load({
@@ -16,7 +16,7 @@ new LambdaStack(app, "sqs", {// NOSONAR
   codePath: resolve(__dirname, "../dist"),
   layerPath: resolve(__dirname, "../layers"),
   handler: "sqs.handler",
-  runtime: "nodejs16.x",
+  runtime: "nodejs18.x",
   namespace: process.env.NAMESPACE || "",
   environment: process.env.ENV || "",
   delaySeconds: 90,


### PR DESCRIPTION
## Description

Now service dependencies can be deploy via ECR. useImage worked properly, and we moved to node 18 to use use latest LTS

Fixes #27
Fixes #30 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
