### PR TITLE
feat(core): optimise Dockerfile for the services

### DIFF
--- a/packages/arc-audit/Dockerfile
+++ b/packages/arc-audit/Dockerfile
@@ -1,20 +1,47 @@
+# Stage 1: Build Stage
+FROM node:18 AS BUILD_STAGE
+
+# Set to a non-root built-in user `node`
+USER node
+
+# Create app directory (with user `node`)
+RUN mkdir -p /home/node/app
+
+# Set the working directory
+WORKDIR /home/node/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY --chown=node package*.json ./
+
+# Installing all dependencies
+RUN npm install
+
+# Copy files needed for the app build
+COPY --chown=node src ./src
+COPY --chown=node public ./public
+COPY --chown=node tsconfig.json ./
+
+# Run Build Command
+RUN npm run build
+
+# Run node-prune
+RUN npm prune --production
+
+# Stage 2: Final Image
+
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 
-# Install app dependencies
-COPY package*.json ./
-
-RUN npm install
-
-# Bundle app source code
-COPY . .
-
-# Build Loopback app
-RUN npm run build
+# Copy runtime artifacts from the build stage
+COPY --from=BUILD_STAGE /home/node/app/node_modules ./node_modules
+COPY --from=BUILD_STAGE /home/node/app/dist ./dist
+COPY --from=BUILD_STAGE /home/node/app/public ./public
 
 CMD [ "./dist/lambda.handler" ]

--- a/packages/arc-auth/Dockerfile
+++ b/packages/arc-auth/Dockerfile
@@ -1,20 +1,47 @@
+# Stage 1: Build Stage
+FROM node:18 AS BUILD_STAGE
+
+# Set to a non-root built-in user `node`
+USER node
+
+# Create app directory (with user `node`)
+RUN mkdir -p /home/node/app
+
+# Set the working directory
+WORKDIR /home/node/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY --chown=node package*.json ./
+
+# Installing all dependencies
+RUN npm install
+
+# Copy files needed for the app build
+COPY --chown=node src ./src
+COPY --chown=node public ./public
+COPY --chown=node tsconfig.json ./
+
+# Run Build Command
+RUN npm run build
+
+# Run node-prune
+RUN npm prune --production
+
+# Stage 2: Final Image
+
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 
-# Install app dependencies
-COPY package*.json ./
-
-RUN npm install
-
-# Bundle app source code
-COPY . .
-
-# Build Loopback app
-RUN npm run build
+# Copy runtime artifacts from the build stage
+COPY --from=BUILD_STAGE /home/node/app/node_modules ./node_modules
+COPY --from=BUILD_STAGE /home/node/app/dist ./dist
+COPY --from=BUILD_STAGE /home/node/app/public ./public
 
 CMD [ "./dist/lambda.handler" ]

--- a/packages/arc-bpmn/Dockerfile
+++ b/packages/arc-bpmn/Dockerfile
@@ -1,20 +1,47 @@
+# Stage 1: Build Stage
+FROM node:18 AS BUILD_STAGE
+
+# Set to a non-root built-in user `node`
+USER node
+
+# Create app directory (with user `node`)
+RUN mkdir -p /home/node/app
+
+# Set the working directory
+WORKDIR /home/node/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY --chown=node package*.json ./
+
+# Installing all dependencies
+RUN npm install
+
+# Copy files needed for the app build
+COPY --chown=node src ./src
+COPY --chown=node public ./public
+COPY --chown=node tsconfig.json ./
+
+# Run Build Command
+RUN npm run build
+
+# Run node-prune
+RUN npm prune --production
+
+# Stage 2: Final Image
+
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 
-# Install app dependencies
-COPY package*.json ./
-
-RUN npm install
-
-# Bundle app source code
-COPY . .
-
-# Build Loopback app
-RUN npm run build
+# Copy runtime artifacts from the build stage
+COPY --from=BUILD_STAGE /home/node/app/node_modules ./node_modules
+COPY --from=BUILD_STAGE /home/node/app/dist ./dist
+COPY --from=BUILD_STAGE /home/node/app/public ./public
 
 CMD [ "./dist/lambda.handler" ]

--- a/packages/arc-chat/Dockerfile
+++ b/packages/arc-chat/Dockerfile
@@ -1,20 +1,47 @@
+# Stage 1: Build Stage
+FROM node:18 AS BUILD_STAGE
+
+# Set to a non-root built-in user `node`
+USER node
+
+# Create app directory (with user `node`)
+RUN mkdir -p /home/node/app
+
+# Set the working directory
+WORKDIR /home/node/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY --chown=node package*.json ./
+
+# Installing all dependencies
+RUN npm install
+
+# Copy files needed for the app build
+COPY --chown=node src ./src
+COPY --chown=node public ./public
+COPY --chown=node tsconfig.json ./
+
+# Run Build Command
+RUN npm run build
+
+# Run node-prune
+RUN npm prune --production
+
+# Stage 2: Final Image
+
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 
-# Install app dependencies
-COPY package*.json ./
-
-RUN npm install
-
-# Bundle app source code
-COPY . .
-
-# Build Loopback app
-RUN npm run build
+# Copy runtime artifacts from the build stage
+COPY --from=BUILD_STAGE /home/node/app/node_modules ./node_modules
+COPY --from=BUILD_STAGE /home/node/app/dist ./dist
+COPY --from=BUILD_STAGE /home/node/app/public ./public
 
 CMD [ "./dist/lambda.handler" ]

--- a/packages/arc-feature-toggle/Dockerfile
+++ b/packages/arc-feature-toggle/Dockerfile
@@ -1,20 +1,47 @@
+# Stage 1: Build Stage
+FROM node:18 AS BUILD_STAGE
+
+# Set to a non-root built-in user `node`
+USER node
+
+# Create app directory (with user `node`)
+RUN mkdir -p /home/node/app
+
+# Set the working directory
+WORKDIR /home/node/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY --chown=node package*.json ./
+
+# Installing all dependencies
+RUN npm install
+
+# Copy files needed for the app build
+COPY --chown=node src ./src
+COPY --chown=node public ./public
+COPY --chown=node tsconfig.json ./
+
+# Run Build Command
+RUN npm run build
+
+# Run node-prune
+RUN npm prune --production
+
+# Stage 2: Final Image
+
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 
-# Install app dependencies
-COPY package*.json ./
-
-RUN npm install
-
-# Bundle app source code
-COPY . .
-
-# Build Loopback app
-RUN npm run build
+# Copy runtime artifacts from the build stage
+COPY --from=BUILD_STAGE /home/node/app/node_modules ./node_modules
+COPY --from=BUILD_STAGE /home/node/app/dist ./dist
+COPY --from=BUILD_STAGE /home/node/app/public ./public
 
 CMD [ "./dist/lambda.handler" ]

--- a/packages/arc-in-mail/Dockerfile
+++ b/packages/arc-in-mail/Dockerfile
@@ -1,20 +1,47 @@
+# Stage 1: Build Stage
+FROM node:18 AS BUILD_STAGE
+
+# Set to a non-root built-in user `node`
+USER node
+
+# Create app directory (with user `node`)
+RUN mkdir -p /home/node/app
+
+# Set the working directory
+WORKDIR /home/node/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY --chown=node package*.json ./
+
+# Installing all dependencies
+RUN npm install
+
+# Copy files needed for the app build
+COPY --chown=node src ./src
+COPY --chown=node public ./public
+COPY --chown=node tsconfig.json ./
+
+# Run Build Command
+RUN npm run build
+
+# Run node-prune
+RUN npm prune --production
+
+# Stage 2: Final Image
+
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 
-# Install app dependencies
-COPY package*.json ./
-
-RUN npm install
-
-# Bundle app source code
-COPY . .
-
-# Build Loopback app
-RUN npm run build
+# Copy runtime artifacts from the build stage
+COPY --from=BUILD_STAGE /home/node/app/node_modules ./node_modules
+COPY --from=BUILD_STAGE /home/node/app/dist ./dist
+COPY --from=BUILD_STAGE /home/node/app/public ./public
 
 CMD [ "./dist/lambda.handler" ]

--- a/packages/arc-notification/Dockerfile
+++ b/packages/arc-notification/Dockerfile
@@ -1,20 +1,47 @@
+# Stage 1: Build Stage
+FROM node:18 AS BUILD_STAGE
+
+# Set to a non-root built-in user `node`
+USER node
+
+# Create app directory (with user `node`)
+RUN mkdir -p /home/node/app
+
+# Set the working directory
+WORKDIR /home/node/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY --chown=node package*.json ./
+
+# Installing all dependencies
+RUN npm install
+
+# Copy files needed for the app build
+COPY --chown=node src ./src
+COPY --chown=node public ./public
+COPY --chown=node tsconfig.json ./
+
+# Run Build Command
+RUN npm run build
+
+# Run node-prune
+RUN npm prune --production
+
+# Stage 2: Final Image
+
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 
-# Install app dependencies
-COPY package*.json ./
-
-RUN npm install
-
-# Bundle app source code
-COPY . .
-
-# Build Loopback app
-RUN npm run build
+# Copy runtime artifacts from the build stage
+COPY --from=BUILD_STAGE /home/node/app/node_modules ./node_modules
+COPY --from=BUILD_STAGE /home/node/app/dist ./dist
+COPY --from=BUILD_STAGE /home/node/app/public ./public
 
 CMD [ "./dist/lambda.handler" ]

--- a/packages/arc-payment/Dockerfile
+++ b/packages/arc-payment/Dockerfile
@@ -1,20 +1,47 @@
+# Stage 1: Build Stage
+FROM node:18 AS BUILD_STAGE
+
+# Set to a non-root built-in user `node`
+USER node
+
+# Create app directory (with user `node`)
+RUN mkdir -p /home/node/app
+
+# Set the working directory
+WORKDIR /home/node/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY --chown=node package*.json ./
+
+# Installing all dependencies
+RUN npm install
+
+# Copy files needed for the app build
+COPY --chown=node src ./src
+COPY --chown=node public ./public
+COPY --chown=node tsconfig.json ./
+
+# Run Build Command
+RUN npm run build
+
+# Run node-prune
+RUN npm prune --production
+
+# Stage 2: Final Image
+
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 
-# Install app dependencies
-COPY package*.json ./
-
-RUN npm install
-
-# Bundle app source code
-COPY . .
-
-# Build Loopback app
-RUN npm run build
+# Copy runtime artifacts from the build stage
+COPY --from=BUILD_STAGE /home/node/app/node_modules ./node_modules
+COPY --from=BUILD_STAGE /home/node/app/dist ./dist
+COPY --from=BUILD_STAGE /home/node/app/public ./public
 
 CMD [ "./dist/lambda.handler" ]

--- a/packages/arc-scheduler/Dockerfile
+++ b/packages/arc-scheduler/Dockerfile
@@ -1,20 +1,47 @@
+# Stage 1: Build Stage
+FROM node:18 AS BUILD_STAGE
+
+# Set to a non-root built-in user `node`
+USER node
+
+# Create app directory (with user `node`)
+RUN mkdir -p /home/node/app
+
+# Set the working directory
+WORKDIR /home/node/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY --chown=node package*.json ./
+
+# Installing all dependencies
+RUN npm install
+
+# Copy files needed for the app build
+COPY --chown=node src ./src
+COPY --chown=node public ./public
+COPY --chown=node tsconfig.json ./
+
+# Run Build Command
+RUN npm run build
+
+# Run node-prune
+RUN npm prune --production
+
+# Stage 2: Final Image
+
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 
-# Install app dependencies
-COPY package*.json ./
-
-RUN npm install
-
-# Bundle app source code
-COPY . .
-
-# Build Loopback app
-RUN npm run build
+# Copy runtime artifacts from the build stage
+COPY --from=BUILD_STAGE /home/node/app/node_modules ./node_modules
+COPY --from=BUILD_STAGE /home/node/app/dist ./dist
+COPY --from=BUILD_STAGE /home/node/app/public ./public
 
 CMD [ "./dist/lambda.handler" ]

--- a/packages/arc-search/Dockerfile
+++ b/packages/arc-search/Dockerfile
@@ -1,20 +1,47 @@
+# Stage 1: Build Stage
+FROM node:18 AS BUILD_STAGE
+
+# Set to a non-root built-in user `node`
+USER node
+
+# Create app directory (with user `node`)
+RUN mkdir -p /home/node/app
+
+# Set the working directory
+WORKDIR /home/node/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY --chown=node package*.json ./
+
+# Installing all dependencies
+RUN npm install
+
+# Copy files needed for the app build
+COPY --chown=node src ./src
+COPY --chown=node public ./public
+COPY --chown=node tsconfig.json ./
+
+# Run Build Command
+RUN npm run build
+
+# Run node-prune
+RUN npm prune --production
+
+# Stage 2: Final Image
+
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 
-# Install app dependencies
-COPY package*.json ./
-
-RUN npm install
-
-# Bundle app source code
-COPY . .
-
-# Build Loopback app
-RUN npm run build
+# Copy runtime artifacts from the build stage
+COPY --from=BUILD_STAGE /home/node/app/node_modules ./node_modules
+COPY --from=BUILD_STAGE /home/node/app/dist ./dist
+COPY --from=BUILD_STAGE /home/node/app/public ./public
 
 CMD [ "./dist/lambda.handler" ]

--- a/packages/arc-user-tenant/Dockerfile
+++ b/packages/arc-user-tenant/Dockerfile
@@ -1,20 +1,47 @@
+# Stage 1: Build Stage
+FROM node:18 AS BUILD_STAGE
+
+# Set to a non-root built-in user `node`
+USER node
+
+# Create app directory (with user `node`)
+RUN mkdir -p /home/node/app
+
+# Set the working directory
+WORKDIR /home/node/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY --chown=node package*.json ./
+
+# Installing all dependencies
+RUN npm install
+
+# Copy files needed for the app build
+COPY --chown=node src ./src
+COPY --chown=node public ./public
+COPY --chown=node tsconfig.json ./
+
+# Run Build Command
+RUN npm run build
+
+# Run node-prune
+RUN npm prune --production
+
+# Stage 2: Final Image
+
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 
-# Install app dependencies
-COPY package*.json ./
-
-RUN npm install
-
-# Bundle app source code
-COPY . .
-
-# Build Loopback app
-RUN npm run build
+# Copy runtime artifacts from the build stage
+COPY --from=BUILD_STAGE /home/node/app/node_modules ./node_modules
+COPY --from=BUILD_STAGE /home/node/app/dist ./dist
+COPY --from=BUILD_STAGE /home/node/app/public ./public
 
 CMD [ "./dist/lambda.handler" ]

--- a/packages/arc-video-conferencing/Dockerfile
+++ b/packages/arc-video-conferencing/Dockerfile
@@ -1,20 +1,47 @@
+# Stage 1: Build Stage
+FROM node:18 AS BUILD_STAGE
+
+# Set to a non-root built-in user `node`
+USER node
+
+# Create app directory (with user `node`)
+RUN mkdir -p /home/node/app
+
+# Set the working directory
+WORKDIR /home/node/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY --chown=node package*.json ./
+
+# Installing all dependencies
+RUN npm install
+
+# Copy files needed for the app build
+COPY --chown=node src ./src
+COPY --chown=node public ./public
+COPY --chown=node tsconfig.json ./
+
+# Run Build Command
+RUN npm run build
+
+# Run node-prune
+RUN npm prune --production
+
+# Stage 2: Final Image
+
 # Check out https://hub.docker.com/_/node to select a new base image
-FROM public.ecr.aws/lambda/nodejs:18-x86_64 AS BUILD_IMAGE
+FROM public.ecr.aws/lambda/nodejs:18-x86_64
 
 # Create app directory
 RUN mkdir -p ${LAMBDA_TASK_ROOT}
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 
-# Install app dependencies
-COPY package*.json ./
-
-RUN npm install
-
-# Bundle app source code
-COPY . .
-
-# Build Loopback app
-RUN npm run build
+# Copy runtime artifacts from the build stage
+COPY --from=BUILD_STAGE /home/node/app/node_modules ./node_modules
+COPY --from=BUILD_STAGE /home/node/app/dist ./dist
+COPY --from=BUILD_STAGE /home/node/app/public ./public
 
 CMD [ "./dist/lambda.handler" ]


### PR DESCRIPTION
## Description
Optimised Dockerfile for the prod usage.

## Observations

Here are some key observations regarding the image build sizes for the `arc-auth` service at tag `0.1.4`:

1. **Mono Repo Setup and Dependency Management:**
   In our mono repo setup, there's a distinct characteristic where services do not have individual `package-lock.json` files; instead, we have a top-level `package-lock.json`. This prevents us from utilizing `npm ci` effectively. While many online mono repos follow a structure where services depend on packages, allowing selective dependency management, our project diverges from this approach like [here](https://stackoverflow.com/questions/59320343/how-to-build-docker-images-in-a-lerna-monorepo-without-publishing). Using `npm install` alone results in an image build size of approximately 1.5GB. Adding `npm cache clean --force` to the process reduces it to around 1.3GB.

2. **Leveraging Multi-Stage Builds for Lightweight Images:**
   Implementing multi-stage builds can significantly reduce the image's final size. As described in [Docker's documentation](https://docs.docker.com/develop/develop-images/multistage-build/), multi-stage builds enable us to perform code compilation in larger preliminary images. We then selectively copy only the essential artifacts into the final container image while discarding the preliminary build steps. This streamlined approach reduces both the overall size and the attack surface of the container image by excluding build-time dependencies from the runtime image.

- **Challenges with Alpine and Solutions:**
   While incorporating `node prune` and using the `node:18-alpine` image, we encountered an error related to `libc.musl-x86_64.so.1`. A similar issue is discussed [here](https://github.com/mhart/alpine-node#caveats). Alpine Linux's reliance on `musl` can lead to compatibility issues, especially when binaries compiled with `glibc`-like behavior are involved. To address this, there's an option to recompile these binaries to use `musl` (best done by compiling on Alpine).
   If encountering an error resembling "error loading shared library ld-linux-x86-64.so.2," a potential remedy is to add `RUN apk add --no-cache libc6-compat` or `RUN ln -s /lib/libc.musl-x86_64.so.1 /lib/ld-linux-x86-64.so.2` to your Dockerfile.
   As a straightforward solution, adjusting the `BUILD_STAGE` image from `node:18-alpine` to `node:18` can mitigate the problem. Since we are adopting multi-stage builds, the choice between `node:18` and `node:18-alpine` for the build stage doesn't significantly impact the outcome.
   
   Through the adoption of multi-stage builds and leveraging `npm prune`, we managed to achieve a nearly 50% reduction in image build size compared to the previous scenario. The resulting image build size now stands at approximately 750MB.

## References

1. [https://stackoverflow.com/questions/59320343/how-to-build-docker-images-in-a-lerna-monorepo-without-publishing](https://stackoverflow.com/questions/59320343/how-to-build-docker-images-in-a-lerna-monorepo-without-publishing)
2. [Multi Stage Build](https://docs.docker.com/develop/develop-images/multistage-build/)
3. [https://github.com/mhart/alpine-node#caveats](https://github.com/mhart/alpine-node#caveats)
4. [https://aws.amazon.com/blogs/compute/optimizing-lambda-functions-packaged-as-container-images/](https://aws.amazon.com/blogs/compute/optimizing-lambda-functions-packaged-as-container-images/)
5. [https://www.docker.com/blog/keep-nodejs-rockin-in-docker/#](https://www.docker.com/blog/keep-nodejs-rockin-in-docker/#)

Fixes #37 

